### PR TITLE
AEAA-402: Windows extraction scripts

### DIFF
--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,13 @@
+Copyright 2023 metaeffekt and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # metaeffekt-extraction-script
+
 Scripts for extracting detailed information from a host.
 
 The script should only be run in non-production environments, as it collects a
@@ -13,15 +14,47 @@ look at the [{metæffekt} inventory script](https://github.com/org-metaeffekt/me
 
 This figure illustrates how the script can be applied in a staged environment.
 
-## Running the script
-### Optional Arguments:
-- \-t \<machineTag\> : Adds a tag to be stored with the analysis.
+## Linux
+
+### Running the script
+
+#### Optional Arguments:
+
+- `-t <machineTag>` : Adds a tag to be stored with the analysis.
   This exists so that a custom Identifier can be set.
   It should consist only of characters as allowed for base64 encoded strings
   (alphanumeric plus . and /).
-- \-e \<pattern\> : Exclude the path denoted by the pattern.
+- `-e <pattern>` : Exclude the path denoted by the pattern.
   The pattern follows the rules that the command `find` uses for its `-path` options (which aren't always intuitive).
   <br>
-  For directories without overly odd characters, however, it works something like this: <br>
-  `-e "/do/not/traverse/this/directory" -e "/other/patterns*/to/exclude"` <br>
+  For directories without overly odd characters, however, it works something like this:  
+  `-e "/do/not/traverse/this/directory" -e "/other/patterns*/to/exclude"`  
   Take care to not include trailing slashes in your exclude paths, as `find` doesn't cope with it very well.
+
+## Windows
+
+The [scripts-windows](scripts-windows) folder contains multiple PowerShell scripts that are all required to run the
+extraction script on Windows. Only the [windows-extractor.ps1](scripts-windows/windows-extractor.ps1) script needs to
+be executed. The other scripts are called by the main script.
+
+### Running the script
+
+```powershell
+.\windows-extractor.ps1 -OutDir result
+```
+
+#### Optional arguments:
+
+- `-FsScanBaseDir` : The base directory for the filesystem scan. This is the directory that will be scanned for files
+  and directories. The default value is `(Get-WmiObject Win32_OperatingSystem).SystemDrive` or if that fails,  `C:\`.
+- `FsScanExcludeDirs` : A string consisting of directories split by `;;;` to exclude from scanning into during the
+  file system scan: `"dir1;;;dir2;;;dir3"`
+
+### Result processing
+
+The results can be converted into an inventory of software components using the `extract-windows-inventory` goal of
+the `org.metaeffekt.core` : `ae-inventory-maven-plugin` plugin.
+
+## License
+
+- The files in the [scripts-windows](scripts-windows) are licensed under the [MIT license](LICENSE.MIT).

--- a/scripts-windows/ExportRegistrySubtree.ps1
+++ b/scripts-windows/ExportRegistrySubtree.ps1
@@ -1,0 +1,52 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$RegistryPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutFile
+)
+
+function ensureParentDirectoryExists([string]$filePath) {
+    $parentDir = [System.IO.Path]::GetDirectoryName($filePath)
+
+    if (-Not(Test-Path $parentDir)) {
+        New-Item -Path $parentDir -Type Directory -Force
+    }
+}
+
+ensureParentDirectoryExists $OutFile
+
+Write-Host "Exporting subtree from registry path: $RegistryPath"
+Write-Progress -Status "Initializing" -PercentComplete 0 -Activity "Processing key"
+
+# recursively get all child items (keys and values) under the registry path
+$items = Get-ChildItem -Path $RegistryPath -Recurse
+$totalItems = $items.Count
+$currentItem = 0
+
+$registryData = @()
+
+foreach ($item in $items) {
+    $currentItem++
+    $percentComplete = ($currentItem / $totalItems) * 100
+
+    Write-Progress -Status $item.PSPath -PercentComplete $percentComplete -Activity "Processing key"
+
+    $temp = [pscustomobject]@{
+        'Key' = $item.PSPath
+        'Properties' = @{ }
+    }
+
+    # Get all the property values under this key
+    $properties = Get-ItemProperty -Path $item.PSPath
+
+    foreach ($propertyName in $properties.PSObject.Properties.Name) {
+        $temp.Properties[$propertyName] = $properties.$propertyName
+    }
+
+    $registryData += $temp
+}
+
+$registryData | ConvertTo-Json | Out-File $OutFile -Encoding utf8
+
+Write-Progress -Completed -Status "Completed" -Activity "Processing key"

--- a/scripts-windows/FilesystemScan.ps1
+++ b/scripts-windows/FilesystemScan.ps1
@@ -1,0 +1,96 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $BaseDir,
+    [Parameter(Mandatory = $true)]
+    [string] $OutFileFiles,
+    [Parameter(Mandatory = $true)]
+    [string] $OutFileDirs,
+    [Parameter(Mandatory = $true)]
+    [string] $OutFileSymlinks,
+    [string] $ExcludeDirs
+)
+
+function ensureParentDirectoryExists([string]$filePath) {
+    $parentDir = [System.IO.Path]::GetDirectoryName($filePath)
+    if (-Not(Test-Path $parentDir)) {
+        New-Item -Path $parentDir -Type Directory -Force
+    }
+}
+
+ensureParentDirectoryExists $OutFileFiles
+ensureParentDirectoryExists $OutFileDirs
+ensureParentDirectoryExists $OutFileSymlinks
+
+$ExcludeDirsSplit = @()
+if ($ExcludeDirs -is [string] -and $ExcludeDirs -ne '') {
+    $ExcludeDirsSplit = $ExcludeDirs -split ';;;'
+}
+
+Write-Host "BaseDir: $BaseDir"
+Write-Host "ExcludeDirs: $ExcludeDirsSplit"
+
+$allFiles = New-Object 'System.Collections.ArrayList'
+$allDirs = New-Object 'System.Collections.ArrayList'
+$allSymlinks = New-Object 'System.Collections.ArrayList'
+
+$stack = New-Object 'System.Collections.Stack'
+$stack.Push($BaseDir)
+
+$counter = 0
+$startTime = Get-Date
+
+while ($stack.Count -gt 0) {
+    $currentDir = $stack.Pop()
+
+    if ($ExcludeDirsSplit -contains $currentDir) {
+        continue
+    }
+
+    $counter++
+    if ($counter % 500 -eq 0) {
+        Write-Progress -PercentComplete (($counter / ($stack.Count + $counter)) * 100) -Status "Processing" -CurrentOperation $currentDir -Activity "Processing filesystem"
+    }
+
+    $items = Get-ChildItem -Path $currentDir -Force -ErrorAction SilentlyContinue
+
+    foreach ($item in $items) {
+        if ($item.PSIsContainer) {
+            if ($item.Attributes -match "ReparsePoint") {
+                $null = $allSymlinks.Add($item.FullName)
+            } else {
+                $null = $allDirs.Add($item.FullName)
+            }
+            $stack.Push($item.FullName)
+        } else {
+            if ($item.Attributes -match "ReparsePoint") {
+                $null = $allSymlinks.Add($item.FullName)
+            } else {
+                $null = $allFiles.Add($item.FullName)
+            }
+        }
+    }
+}
+
+Write-Progress -Completed -Status "Done" -Activity "Processing filesystem"
+
+$endTime = Get-Date
+$diff = New-TimeSpan -Start $startTime -End $endTime
+
+# output statistics
+Write-Host "Finished processing filesystem. Results:"
+Write-Host "      files: $( $allFiles.Count )"
+Write-Host "   symlinks: $( $allSymlinks.Count )"
+Write-Host "directories: $( $allDirs.Count )"
+Write-Host "      total: $( ($allFiles.Count + $allSymlinks.Count + $allDirs.Count) )"
+Write-Host " total time: $( $diff.TotalSeconds ) seconds"
+Write-Host ""
+Write-Host "Writing results to files:"
+
+# output to files
+Write-Host "  - $OutFileFiles"
+$allFiles -join "`r`n" | Out-File $OutFileFiles
+Write-Host "  - $OutFileDirs"
+$allDirs -join "`r`n" | Out-File $OutFileDirs
+Write-Host "  - $OutFileSymlinks"
+$allSymlinks -join "`r`n" | Out-File $OutFileSymlinks
+Write-Host "Done"

--- a/scripts-windows/WmixQueryRelevantClasses.ps1
+++ b/scripts-windows/WmixQueryRelevantClasses.ps1
@@ -1,0 +1,72 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $OutDir
+)
+
+$classes = @(
+    'Win32_InstalledWin32Program',
+    'Win32_InstalledStoreProgram',
+    'Win32_InstalledProgramFramework',
+    'Win32_Bios',
+    'Win32_OperatingSystem',
+    'Win32_ComputerSystem',
+    'Win32_Processor',
+    'Win32_LogicalDisk',
+    'Win32_NetworkAdapterConfiguration',
+    'Win32_NetworkAdapter',
+    'Win32_NetworkLoginProfile',
+    'Win32_NetworkProtocol',
+    'Win32_Service',
+    'Win32_Product',
+    'Win32_SoftwareFeature',
+    'Win32_SoftwareElement',
+    'Win32_SoftwareElementCondition',
+    'Win32_SoftwareFeatureCheck',
+    'Win32_SoftwareFeatureParent',
+    'Win32_SoftwareFeatureSoftwareElements',
+    'Win32_ComputerSystemProduct',
+    'Win32_BaseBoard',
+    'Win32_PhysicalMemory',
+    'Win32_DiskDrive',
+    'Win32_DiskPartition',
+    'Win32_CDROMDrive',
+    'Win32_USBController',
+    'Win32_VideoController',
+    'Win32_SoundDevice',
+    'Win32_PrinterDriver',
+    'Win32_Printer',
+    'Win32_SystemDriver',
+    'Win32_OptionalFeature',
+    'Win32_DisplayConfiguration',
+    'Win32_PnPEntity',
+    'Win32_PnpSignedDriver',
+    'Win32_MotherboardDevice',
+    'CIM_SoftwareElement',
+    'CIM_SoftwareFeature',
+    'CIM_SoftwareFeatureSoftwareElements'
+)
+
+if (!(Test-Path $OutDir)) {
+    New-Item -ItemType directory -Path $OutDir | Out-Null
+}
+
+$totalClasses = $classes.Length
+$counter = 0
+
+Write-Host "Querying $totalClasses WMI classes"
+
+ForEach ($class in $classes) {
+    $counter++
+
+    $percentComplete = ($counter / $totalClasses) * 100
+    Write-Progress -PercentComplete $percentComplete -Status "In Progress" -CurrentOperation $class -Activity "Querying WMI Classes"
+
+    try {
+        powershell -ExecutionPolicy Bypass -File .\WmixQuerySingleClass.ps1 -QueryClass $class -OutFile "$OutDir\$class.json"
+    } catch {
+        Write-Host "There was a problem querying the $class class: $_"
+    }
+}
+
+Write-Progress -Completed -Status "Completed" -Activity "Querying WMI Classes"
+Write-Host "Done querying WMI classes"

--- a/scripts-windows/WmixQuerySingleClass.ps1
+++ b/scripts-windows/WmixQuerySingleClass.ps1
@@ -1,0 +1,285 @@
+#Requires -Version 4
+#Requires -RunAsAdministrator
+
+<#
+.SYNOPSIS
+    A versatile WMI Script for querying installed programs.
+
+    WHAT IT DOES: This script can be run against the local machine, or a single or list of remote machines.
+    It queries instances of installed Win32 programs or installed Store programs and optionally
+    converts property names and values to more human-friendly formats.
+
+.EXAMPLE
+	PS> .\WmixQuerySingleClass.ps1 -QueryClass 'Win32_InstalledWin32Program'
+		Run this script on the local machine to query installed Win32 programs.
+		Output property names and values are converted to friendly values.
+
+.EXAMPLE
+	PS> .\WmixQuerySingleClass.ps1 -QueryClass 'Win32_InstalledWin32Program' -ComputerName 'computer1'
+		Run this script on computer1 to query installed Win32 programs.
+		Output property names and values are converted to friendly values.
+
+.EXAMPLE
+	PS> .\WmixQuerySingleClass.ps1 -QueryClass 'Win32_InstalledStoreProgram' -ComputerName 'computer1','computer2'
+		Run this script on computer1 and computer2 to query installed Store programs.
+		Output property names and values are converted to friendly values.
+
+.EXAMPLE
+	PS> $MyCredentials = Get-Credential
+	PS> .\WmixQuerySingleClass.ps1 -QueryClass 'Win32_InstalledWin32Program' -ComputerName 'computer1' -Credential $MyCredentials
+		Run this script on computer1 using the specified credentials to query installed Win32 programs.
+
+.EXAMPLE
+	PS> .\WmixQuerySingleClass.ps1 -QueryClass 'Win32_InstalledWin32Program' -ComputerName 'computer1' -NoFriendlyNames
+		Run this script on computer1 to query installed Win32 programs.
+		Output property names and values are NOT converted to friendly values.
+
+.PARAMETER ComputerName
+	The name of the computer you'd like to run this function against. This defaults to 'localhost'.  You can also
+	specify either a single or multiple comma-separated remote hosts as well.
+
+.PARAMETER Credential
+	The credentials to use to execute the WMI calls. This defaults to the local user's credentials.
+
+.PARAMETER NoFriendlyNames
+	WMI can return some obsure property names and values. This script automatically converts property names and values to
+	human friendly values. Use this switch parameter to turn of this option.
+
+.PARAMETER Impersonation
+	Specifies the impersonation level to use. Valid values are:
+		0: Default. Reads the local registry for the default impersonation level , which is usually set to '3: Impersonate'
+		1: Anonymous. Hides the credentials of the caller.
+		2: Identify. Allows objects to query the credentials of the caller.
+		3: Impersonate. Allows objects to use the credentials of the caller.
+		4: Delegate. Allows objects to permit other objects to use the credentials of the caller.
+
+.PARAMETER Authentication
+	Specifies the authentication level to be used with the WMI connection. Valid values are:
+		-1: Unchanged
+		0: Default
+		1: None (No authentication in performed.)
+		2: Connect (Authentication is performed only when the client establishes a relationship with the application.)
+		3: Call (Authentication is performed only at the beginning of each call when the application receives the request.)
+		4: Packet (Authentication is performed on all the data that is received from the client.)
+		5: PacketIntegrity (All the data that is transferred between the client and the application is authenticated and verified.)
+		6: PacketPrivacy (The properties of the other authentication levels are used, and all the data is encrypted.)
+
+.PARAMETER QueryClass
+  Mandatory parameter that specifies the WMI class to query. Valid classes are 'Win32_InstalledWin32Program' and 'Win32_InstalledStoreProgram'
+
+.INPUTS
+	None. You cannot pipe objects to wmix_QueryInstances_InstalledWin32Program.ps1.
+
+.OUTPUTS
+	Selected.System.Management.ManagementObject,System.Management.Automation.PSCustomObject.
+#>
+
+    [CmdletBinding()]
+    [OutputType()]
+param
+(
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string[]]
+    $ComputerName = $env:COMPUTERNAME,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [pscredential]
+    $Credential,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [switch]
+    $NoFriendlyNames = $False,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [ValidateRange(0, 4)]
+    [int]
+    $Impersonation,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [ValidateRange(0, 6)]
+    [int]
+    $Authentication,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $QueryClass,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $OutFile
+)
+
+
+
+process {
+    try {
+        Write-Verbose -Message "WMIX (R) Scriptor v3 - wmix.goverlan.com"
+        Write-Verbose -Message " starting execution..."
+
+        foreach ($computer in $ComputerName) {
+            try {
+                if (-not(Test-Connection -ComputerName $computer -Quiet -Count 1)) {
+                    Write-Warning "[$computer] is offline and will not be processed"
+                }
+                else {
+                    Write-Verbose -Message "The computer [$( $computer )] is online. Proceeding..."
+
+                    # find friendly property names from the QueryClass
+                    $friendly_PropName
+                    switch ($QueryClass) {
+                        'Win32_InstalledWin32Program' {
+                            $friendly_PropName = $friendly_InstalledWin32Program_PropName
+                        }
+                        'Win32_InstalledStoreProgram' {
+                            $friendly_PropName = $friendly_InstalledStoreProgram_PropName
+                        }
+                        'Win32_InstalledProgramFramework' {
+                            $friendly_PropName = $friendly_InstalledProgramFramework_PropName
+                        }
+                        default {
+                            $friendly_PropName = @{ }
+                        }
+                    }
+
+                    # >>>>>>>>>>>>>>>>>>
+                    $result = (queryInstalledWin32ProgramInstances $computer $QueryClass $friendly_PropName) | ConvertTo-Json -Depth 4
+                    if ($OutFile) {
+                        ensureParentDirectoryExists $OutFile
+                        $result | Out-File -FilePath $OutFile -Encoding utf8
+                    }
+                    else {
+                        $result
+                    }
+                    # <<<<<<<<<<<<<<<<<<
+                }
+            } catch {
+                Write-Error "Unable to perform WMI action on [$computer] - $( $_.Exception.Message )"
+            }
+        }
+    } catch {
+        Write-Error $_.Exception.Message
+    } finally {
+        Write-Verbose -Message 'WMIX script by GoverLAN complete'
+    }
+}
+
+
+begin
+{
+    function ensureParentDirectoryExists([string]$filePath) {
+        $parentDir = [System.IO.Path]::GetDirectoryName($filePath)
+
+        if (-Not(Test-Path $parentDir)) {
+            New-Item -Path $parentDir -Type Directory -Force
+        }
+    }
+
+    Function queryInstalledWin32ProgramInstances([string]$computer, [string]$queryClass, [hashtable]$friendly_PropName) {
+        $wmiParams = @{
+            'ComputerName' = $computer
+            'Namespace' = 'ROOT\CIMV2'
+            'Class' = $queryClass
+            'Filter' = ''
+            'Property' = '*'
+        }
+
+        if ( $script:PSBoundParameters.ContainsKey('Credential')) {
+            $wmiParams.Credential = $Credential
+            Write-Verbose -Message "Using specified credentials."
+        }
+
+        if ( $script:PSBoundParameters.ContainsKey('Authentication')) {
+            $wmiParams.Authentication = $Authentication
+        }
+
+        if ( $script:PSBoundParameters.ContainsKey('Impersonation')) {
+            $wmiParams.Impersonation = $Impersonation
+        }
+
+        Write-Verbose -Message "Querying [$( $queryClass )] Instances on computer [$( $computer )]..."
+
+        $instanceSet = (Get-WmiObject @wmiParams)
+        $output = @()
+        foreach ($instance in $instanceSet) {
+            $temp = [pscustomobject]@{
+                'Computer' = $computer
+            }
+            $instance.psbase.psobject.baseobject.properties | foreach {
+                $temp | Add-Member -NotePropertyName (convertVal $_.Name $null $friendly_PropName) -NotePropertyValue $_.Value
+            }
+            $output += $temp
+        }
+        return $output
+    }
+
+    ###############################################################
+
+    # decodeVal converts a WMI raw value to a friendly format based on the optional specified array and optional unit (unless NoFriendlyValue is turned ON)
+    function convertVal([array]$unfriendlyValue, [string]$valueUnit, [hashtable]$hashValues = $null) {
+        # check for empty array (no value) or if NoFriendlyNames is enabled
+        if ($unfriendlyValue.Count -eq 0 -or $NoFriendlyNames -eq $True) {
+            return $unfriendlyValue
+        }
+
+        # either a single value or an array of values
+        if ($unfriendlyValue.Count -eq 1) {
+            $friendlyValue = $unfriendlyValue[0] -as [string]
+
+            if ($hashValues -ne $null -and $hashValues.Contains($friendlyValue)) {
+                # check if a friendly version exists in the provided hashtable
+                $friendlyValue = $hashValues[$friendlyValue]
+            }
+
+            if ($valueUnit) {
+                # append any unit that may exist (like 'bytes' or 'GHz') to the value
+                $friendlyValue += " " + $valueUnit
+            }
+
+            return $friendlyValue
+        }
+        else {
+            $friendlyValue = "{"
+
+            foreach ($arrayVal in $unfriendlyValue) {
+                # recursive call to handle each of the array's values individually
+                $friendlyValue += (convertVal $arrayVal $valueUnit) + ", "
+            }
+
+            # trim any trailing commas/spaces and close the braces
+            $friendlyValue = $friendlyValue.Trim().TrimEnd(",") + "}"
+
+            return $friendlyValue;
+        }
+    }
+
+    ###############################################################
+
+    # Array of friendly values for the property names of the Installed Win32 Program WMI Class
+    $friendly_InstalledWin32Program_PropName = @{
+        'MsiPackageCode' = 'Msi Package Code'
+        'MsiProductCode' = 'Msi Product Code'
+        'ProgramId' = 'Program Id'
+    }
+
+    # Array of friendly values for the property names of the Installed Store Program WMI Class
+    $friendly_InstalledStoreProgram_PropName = @{
+        'ProgramId' = 'Program Id'
+    }
+
+    # Array of friendly values for the property names of the Installed Program Framework WMI Class
+    $friendly_InstalledProgramFramework_PropName = @{
+        'FrameworkName' = 'Framework Name'
+        'FrameworkPublisher' = 'Framework Publisher'
+        'FrameworkVersion' = 'Framework Version'
+        'FrameworkVersionActual' = 'Framework Version Actual'
+        'IsPrivate' = 'Is Private'
+        'ProgramId' = 'Program Id'
+    }
+}

--- a/scripts-windows/windows-extractor.ps1
+++ b/scripts-windows/windows-extractor.ps1
@@ -1,0 +1,116 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $OutDir,
+
+    [Parameter(Mandatory = $false)]
+    [string]
+    $FsScanBaseDir,
+
+    [Parameter(Mandatory = $false)]
+    [string]
+    $FsScanExcludeDirs
+)
+
+function getDefaultFsScanBaseDir() {
+    if ((Get-WmiObject Win32_OperatingSystem -ErrorAction SilentlyContinue).SystemDrive) {
+        return (Get-WmiObject Win32_OperatingSystem).SystemDrive
+    }
+    else {
+        return "C:\"
+    }
+}
+
+if (-Not$FsScanBaseDir) {
+    $FsScanBaseDir = getDefaultFsScanBaseDir
+}
+
+if (-Not$FsScanExcludeDirs) {
+    $FsScanExcludeDirs = ""
+}
+
+function Write-PaddedMessage([string] $message) {
+    # may be adjusted for target length
+    $totalLength = 64
+    $messageLength = $message.Length
+
+    $numDashesEachSide = ($totalLength - $messageLength - 2) / 2
+
+    $dashString = '-' * [Math]::Floor($numDashesEachSide)
+
+    Write-Host ""
+    Write-Host "$dashString $message $dashString"
+    Write-Host ""
+}
+
+function Create-OutFile([string] $fileName) {
+    return ".\$OutDir\$fileName"
+}
+
+
+# ensure output directory exists
+if (-Not(Test-Path $OutDir)) {
+    New-Item -Path $OutDir -Type Directory -Force
+}
+
+
+$tasks = @(
+    {
+        # add -ExcludeDirs "dir1;;;dir2;;;dir3" to exclude directories from scan
+        Write-PaddedMessage "Collecting files in file system"
+        .\FilesystemScan.ps1 -BaseDir $FsScanBaseDir -OutFileFiles (Create-OutFile "FileSystemFilesList.txt") -OutFileDirs (Create-OutFile "FileSystemDirsList.txt") -OutFileSymlinks (Create-OutFile "FileSystemSymlinksList.txt") -ExcludeDirs $FsScanExcludeDirs
+    },
+    {
+        Write-PaddedMessage "Querying WMI classes"
+        .\WmixQueryRelevantClasses.ps1 -OutDir $OutDir
+    },
+    {
+        Write-PaddedMessage "Exporting registry subtrees"
+        .\ExportRegistrySubtree.ps1 -RegistryPath "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall" -OutFile (Create-OutFile "RegistrySubtree-windows-uninstall.json")
+    },
+    {
+        Write-PaddedMessage "Getting Windows version"
+        Write-Host "[System.Environment]::OSVersion.Version"
+        [System.Environment]::OSVersion.Version | Out-File (Create-OutFile "OSVersion.Version.txt")
+    },
+    {
+        Write-PaddedMessage "Getting system information"
+        Write-Host "systeminfo /fo csv"
+        systeminfo /fo csv | ConvertFrom-Csv | ConvertTo-Json | Out-File (Create-OutFile "systeminfo.json")
+        Write-Host "Get-ComputerInfo"
+        Get-ComputerInfo | ConvertTo-Json | Out-File (Create-OutFile "Get-ComputerInfo.json")
+    },
+    {
+        Write-PaddedMessage "Getting PnP devices information"
+        Write-Host "Get-PnpDevice"
+        Get-PnpDevice | ConvertTo-Json | Out-File (Create-OutFile "Get-PnpDevice.json")
+    }
+)
+
+
+$taskFailed = $false
+$startTime = Get-Date
+
+foreach ($task in $tasks) {
+    try {
+        $task.Invoke()
+    } catch {
+        Write-Host "Error: $_"
+        Write-PaddedMessage "Previous task failed"
+        $script:taskFailed = $true
+    }
+}
+
+$endTime = Get-Date
+$diff = New-TimeSpan -Start $startTime -End $endTime
+
+
+# check if any task failed and exit with non-zero code if so
+if ($taskFailed) {
+    Write-Host "At least one task failed. Total time: $( $diff.TotalSeconds ) seconds"
+    exit 1
+} else {
+    Write-PaddedMessage "Successfully terminated running all tasks"
+    Write-Host "Finished running all tasks. Total time: $( $diff.TotalSeconds ) seconds"
+}
+


### PR DESCRIPTION
Added a directory `scripts-windows` that contain PowerShell scripts that can extract information from Windows systems via the WMI and other interfaces.

The scripts are all called via the `windows-extractor.ps1` script:

```powershell
.\windows-extractor.ps1 -OutDir result
```

See the updated README.md for more information.
